### PR TITLE
fix #16: multipart/form-data inclues one too many \r\n

### DIFF
--- a/http/src/form.lua
+++ b/http/src/form.lua
@@ -160,7 +160,7 @@ function FormData:build()
 				end
 			end
 
-			content = content .. "\r\n\r\n\r\n" .. val .. "\r\n"
+			content = content .. "\r\n\r\n" .. val .. "\r\n"
 		end
 		content = content .. "--"..self.boundary.."--"
 	end


### PR DESCRIPTION
Removes the extra newline on multipart/form-data so that the exact content sent by the user is sent.